### PR TITLE
Fix readme link to many.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![LittleLink](https://cdn.cottle.cloud/littlelink/social-circle.png)
 
 LittleLink is a lightweight DIY alternative to services like [Linktree](https://linktr.ee)
-and [many.link](https://www.google.com). LittleLink was built using [Skeleton](http://getskeleton.com/), a dead simple, responsive boilerplate—we just stripped out some additional code you wouldn't need and added in branded styles for popular services. 😊
+and [many.link](https://many.link/). LittleLink was built using [Skeleton](http://getskeleton.com/), a dead simple, responsive boilerplate—we just stripped out some additional code you wouldn't need and added in branded styles for popular services. 😊
 
 ![Themes](https://cdn.cottle.cloud/littlelink/themes.png)
 


### PR DESCRIPTION
Hi! This is an *incredibly* menial change, but I noticed that the link to many.link just pointed to google.com, so this PR fixes that, and… yeah, that's it ;)