### PR TITLE
Added options for an avatar radius

### DIFF
--- a/css/skeleton-auto.css
+++ b/css/skeleton-auto.css
@@ -194,3 +194,15 @@ hr {
   border-width: 0;
   border-top: 1px solid #e1e1e1;
 }
+/* Radius values:
+
+10%-40%: Squircles
+50% (default): True circle
+*/
+.avatar {
+  width: 128px;
+  height: 128px;
+  object-fit: cover;
+  background-position: center;
+  border-radius: 50%;
+}

--- a/css/skeleton-dark.css
+++ b/css/skeleton-dark.css
@@ -194,3 +194,15 @@ hr {
   border-width: 0;
   border-top: 1px solid #e1e1e1;
 }
+/* Radius values:
+
+10%-40%: Squircles
+50% (default): True circle
+*/
+.avatar {
+  width: 128px;
+  height: 128px;
+  object-fit: cover;
+  background-position: center;
+  border-radius: 50%;
+}

--- a/css/skeleton-light.css
+++ b/css/skeleton-light.css
@@ -194,3 +194,15 @@ hr {
   border-width: 0;
   border-top: 1px solid #e1e1e1;
 }
+/* Radius values:
+
+10%-40%: Squircles
+50% (default): True circle
+*/
+.avatar {
+  width: 128px;
+  height: 128px;
+  object-fit: cover;
+  background-position: center;
+  border-radius: 50%;
+}

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
         -->
 
         <!-- Your Image Here -->
-        <img src="images/avatar.png" srcset="images/avatar@2x.png 2x" alt="LittleLink Logo">
+        <img src="images/avatar.png" class="avatar" srcset="images/avatar@2x.png 2x" alt="LittleLink Logo">
 
         <!-- Title -->
         <h1>LittleLink</h1>


### PR DESCRIPTION
Modified the CSS files to add the `avatar` class, enabling image cropping based on the following radius values:

`border-radius: 0%` - no cropping/native display of image
`border-radius: <10%-40%>` - varying degrees of 'squircle'
`border-radius: 50%` - true circle

I've also added `class="avatar"` in the main HTML file for the image reference.