### PR TITLE
fixed mastodon verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
         <br>
 
         <!-- Mastodon -->
-        <a class="button button-mastodon" href="#" target="_blank" rel="noopener">
+        <a class="button button-mastodon" href="#" target="_blank" rel="me noopener">
             <img class="icon" src="images/icons/mastodon.svg" alt="Mastodon Logo">Mastodon</a>
         <br>
 


### PR DESCRIPTION
Because Mastodon can be self-hosted, it is impossible to add a verification system,
but if the webpage contains an HTML element having both a link to your profile page and a rel="me" attribute,
mastodon will consider the link as your own and add a verified checkmark. 

This commit just append a "me" in the rel attribute of the mastodon button to ease this verification process.

more information can be found here https://docs.joinmastodon.org/user/profile