### PR TITLE
Fix accessibility issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,12 +52,12 @@
             <img class="avatar avatar--rounded" src="images/avatar.png" srcset="images/avatar@2x.png 2x" alt="LittleLink">
 
             <!-- Replace with your name or brand -->
-            <h1 tabindex="0">
+            <h1>
               <div>LittleLink</div>
             </h1>
 
             <!-- Add a short description about yourself or your brand -->
-            <p tabindex="0">An open source DIY Linktree alternative.</p>
+            <p>An open source DIY Linktree alternative.</p>
 
             <!-- All your buttons go here -->
             <div class="button-stack" role="navigation">

--- a/privacy.html
+++ b/privacy.html
@@ -32,43 +32,43 @@
   <body>
     <div class="container-left" role="main">
       <div class="column">
-        <nav role="navigation" aria-label="Back to homepage">
-          <a href="index.html" tabindex="0">← Back to main page</a>
+        <nav role="navigation">
+          <a href="index.html" aria-label="Back to homepage">← Back to main page</a>
         </nav>
     
-        <h1 tabindex="0">Privacy Overview</h1>
+        <h1>Privacy Overview</h1>
     
         <section aria-labelledby="analytics-heading">
-          <h2 id="analytics-heading" tabindex="0">Analytics</h2>
-          <p tabindex="0">The services contained in this section enable the Owner to monitor and analyze web traffic and can be used to keep track of User behavior.</p>
+          <h2 id="analytics-heading">Analytics</h2>
+          <p>The services contained in this section enable the Owner to monitor and analyze web traffic and can be used to keep track of User behavior.</p>
     
-          <h3 tabindex="0">Example LLC</h3>
+          <h3>Example LLC</h3>
           <ul role="list">
-            <li tabindex="0">Personal Data: various types of Data as specified in the privacy policy of the service</li>
+            <li>Personal Data: various types of Data as specified in the privacy policy of the service</li>
             <li><a href="https://example.com/privacy/" target="_blank" rel="noopener">Privacy Policy</a></li>
           </ul>
         </section>
     
         <section aria-labelledby="external-content-heading">
-          <h2 id="external-content-heading" tabindex="0">External Content</h2>
-          <p tabindex="0">This type of service allows you to view content hosted on external platforms directly from the pages of this website and interact with them.</p>
-          <p tabindex="0">This type of service might still collect web traffic data for the pages where the service is installed, even when Users do not use it.</p>
+          <h2 id="external-content-heading">External Content</h2>
+          <p>This type of service allows you to view content hosted on external platforms directly from the pages of this website and interact with them.</p>
+          <p>This type of service might still collect web traffic data for the pages where the service is installed, even when Users do not use it.</p>
     
-          <h3 tabindex="0">Example LLC</h3>
+          <h3>Example LLC</h3>
           <ul role="list">
-            <li tabindex="0">Personal Data: Usage Data; various types of Data as specified in the privacy policy of the service</li>
+            <li>Personal Data: Usage Data; various types of Data as specified in the privacy policy of the service</li>
             <li><a href="https://example.com/privacy/" target="_blank" rel="noopener">Privacy Policy</a></li>
           </ul>
         </section>
     
         <section aria-labelledby="hosting-heading">
-          <h2 id="hosting-heading" tabindex="0">Hosting and Infrastructure</h2>
-          <p tabindex="0">This type of service has the purpose of hosting Data and files that enable this website to exist.</p>
-          <p tabindex="0">Some services among those listed below, if any, may work through geographically distributed servers, making it difficult to determine the actual location where the Personal Data are stored.</p>
+          <h2 id="hosting-heading">Hosting and Infrastructure</h2>
+          <p>This type of service has the purpose of hosting Data and files that enable this website to exist.</p>
+          <p>Some services among those listed below, if any, may work through geographically distributed servers, making it difficult to determine the actual location where the Personal Data are stored.</p>
     
-          <h3 tabindex="0">Example LLC</h3>
+          <h3>Example LLC</h3>
           <ul role="list">
-            <li tabindex="0">Personal Data: various types of Data as specified in the privacy policy of the service</li>
+            <li>Personal Data: various types of Data as specified in the privacy policy of the service</li>
             <li><a href="https://example.com/privacy" target="_blank" rel="noopener">Privacy Policy</a></li>
           </ul>
         </section>


### PR DESCRIPTION
- Removes `tabindex="0"` from non-interactive elements (headings and paragraphs), see [mdn web docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard#focusable_elements_should_have_interactive_semantics)
- Moves `aria-label` from `<nav>` element to `<a>` element (necessary since screen readers only read out the `<a>` element)